### PR TITLE
DEV-43297 Allow set Content-Type through StyleAnalysisReq for form-data with string content

### DIFF
--- a/src/api/style/style.api.types.ts
+++ b/src/api/style/style.api.types.ts
@@ -110,6 +110,7 @@ export interface StyleAnalysisErrorResp extends ResponseBase {
 
 export interface StyleAnalysisReq {
   content: string | FileDescriptor | BufferDescriptor;
+  content_type?: string; // Optional content type for the file upload, for string content it defaults to text/plain
   style_guide: string; // Can be style guide ID or name (e.g. 'ap', 'chicago', 'microsoft')
   dialect: string;
   tone: string;

--- a/src/api/style/style.api.utils.ts
+++ b/src/api/style/style.api.utils.ts
@@ -135,7 +135,11 @@ export async function createStyleFormData(request: StyleAnalysisReq): Promise<Fo
   const filename = request.documentName || 'unknown.txt';
 
   if (typeof request.content === 'string') {
-    formData.append('file_upload', new Blob([request.content], { type: 'text/plain' }), filename);
+    formData.append(
+      'file_upload',
+      new Blob([request.content], { type: request.content_type || 'text/plain' }),
+      filename,
+    );
   } else if (typeof File !== 'undefined' && 'file' in request.content && request.content.file instanceof File) {
     const fileDescriptor = request.content as FileDescriptor;
     formData.append('file_upload', fileDescriptor.file, filename);


### PR DESCRIPTION
Currently the API only supports text or pdf content, but in the future we will also support html content. So add a `content_type` field to the `StyleAnalysisReq` interface to allow clients specify the content mime type other than `text/plain` (only for `string` type content). 