### PR TITLE
chore: update Vite configuration to include 'buffer' as external depe…

### DIFF
--- a/src/api/style/style.api.utils.ts
+++ b/src/api/style/style.api.utils.ts
@@ -189,7 +189,7 @@ export async function createFile(request: StyleAnalysisReq): Promise<File> {
   }
 }
 
-export async function createContentObject(request: StyleAnalysisReq): Promise<File | import('buffer').Blob> {
+export async function createContentObject(request: StyleAnalysisReq): Promise<File | Blob> {
   // Check if we're in a Node.js environment
   if (isNodeEnvironment()) {
     return createBlob(request);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,9 +11,11 @@ export default defineConfig({
       formats: ['es', 'umd'],
     },
     rollupOptions: {
-      external: [],
+      external: ['buffer'],
       output: {
-        globals: {},
+        globals: {
+          buffer: 'Buffer',
+        },
       },
     },
   },


### PR DESCRIPTION
…ndency

- Added 'buffer' to the external dependencies in Vite configuration to prevent bundling.
- Updated Rollup output globals to map 'buffer' to 'Buffer' for compatibility.